### PR TITLE
Support ssh-key-based workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
-Changelog: dsd-<platformname>
+Changelog: dsd-vps
 ===
 
 0.1 - Provisional support for deployments
 ---
+
+### (Unreleased)
+
+#### External changes
+
+- blah
+
+#### Internal changes
+
+- blah
 
 ### 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `deploy` command will add a new user named `django_user` to the instance, wi
 
 It will add a local ssh key pair for Git, modifying `~/.ssh/config`. The key will be stored at `~/.ssh/id_rsa_git`.
 
-The project will be served over http, which means the browser will probably flag it as insecure.
+The project will be served over http, which means the browser will almost certainly flag it as insecure.
 
 ## Automated deployment - using SSH keys
 
@@ -67,10 +67,10 @@ This is experimental, and you should review the codebase before running this ear
 - Run `python manage.py deploy --automate-all --ssh-key <path_to_ssh_key>`.
     - This command takes a while. If you think it might be hanging, look at your VPS instance dashboard. High CPU means it's probably still updating.
     - For development work, it might be reasonable to use a higher spec instance, that will be destroyed in under an hour.
-    - The deployment will ask you to confirm a fingerprint before connecting. It will also require the root password for the instance.
+    - The deployment will ask you to confirm a fingerprint before connecting.
 
-The `deploy` command will add a new user named `django_user` to the instance, with the same password you originally chose. It will update and configure the server, configure Git on the server, configure the project to be served from the droplet, commit changes, push the project, and open the remote project in a new browser tab.
+The `deploy` command will add a new user named `django_user` to the instance. It will update and configure the server, configure Git on the server, configure the project to be served from the droplet, commit changes, push the project, and open the remote project in a new browser tab.
 
 It will add a local ssh key pair for Git, modifying `~/.ssh/config`. The key will be stored at `~/.ssh/id_rsa_git`.
 
-The project will be served over http, which means the browser will probably flag it as insecure.
+The project will be served over http, which means the browser will almost certainly flag it as insecure.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,26 @@ The `deploy` command will add a new user named `django_user` to the instance, wi
 It will add a local ssh key pair for Git, modifying `~/.ssh/config`. The key will be stored at `~/.ssh/id_rsa_git`.
 
 The project will be served over http, which means the browser will probably flag it as insecure.
+
+## Automated deployment - using SSH keys
+
+This is experimental, and you should review the codebase before running this early version on your system. It will modify local files outside of your project, such as `~/.ssh/config` and `~/.ssh/id_rsa_git`.
+
+- Create a new VPS instance.
+    - I'm Using Ubuntu 24.04 on Digital Ocean for development work; any debian-based OS on any VPS provider should work.
+    - Choose SSH username/password login approach, *not* SSH key (for now).
+- Set two local env vars:
+    - `$ export DSD_HOST_IPADDR=<instance-ip-address>`
+    - `$ export DSD_HOST_PW=<instance-pw>`
+- Install `dsd-vps`. (If you cloned this repo, you probably want to make a local editable install of `dsd-vps`.)
+- Add `django_simple_deploy` to `INSTALLED_APPS`.
+- Run `python manage.py deploy --automate-all`.
+    - This command takes a while. If you think it might be hanging, look at your VPS instance dashboard. High CPU means it's probably still updating.
+    - For development work, it might be reasonable to use a higher spec instance, that will be destroyed in under an hour.
+    - The deployment will ask you to confirm a fingerprint before connecting. It will also require the root password for the instance.
+
+The `deploy` command will add a new user named `django_user` to the instance, with the same password you originally chose. It will update and configure the server, configure Git on the server, configure the project to be served from the droplet, commit changes, push the project, and open the remote project in a new browser tab.
+
+It will add a local ssh key pair for Git, modifying `~/.ssh/config`. The key will be stored at `~/.ssh/id_rsa_git`.
+
+The project will be served over http, which means the browser will probably flag it as insecure.

--- a/README.md
+++ b/README.md
@@ -62,15 +62,9 @@ The project will be served over http, which means the browser will probably flag
 
 This is experimental, and you should review the codebase before running this early version on your system. It will modify local files outside of your project, such as `~/.ssh/config` and `~/.ssh/id_rsa_git`.
 
-- Create a new VPS instance.
-    - I'm Using Ubuntu 24.04 on Digital Ocean for development work; any debian-based OS on any VPS provider should work.
-    - Choose SSH username/password login approach, *not* SSH key (for now).
-- Set two local env vars:
-    - `$ export DSD_HOST_IPADDR=<instance-ip-address>`
-    - `$ export DSD_HOST_PW=<instance-pw>`
 - Install `dsd-vps`. (If you cloned this repo, you probably want to make a local editable install of `dsd-vps`.)
 - Add `django_simple_deploy` to `INSTALLED_APPS`.
-- Run `python manage.py deploy --automate-all`.
+- Run `python manage.py deploy --automate-all --ssh-key <path_to_ssh_key>`.
     - This command takes a while. If you think it might be hanging, look at your VPS instance dashboard. High CPU means it's probably still updating.
     - For development work, it might be reasonable to use a higher spec instance, that will be destroyed in under an hour.
     - The deployment will ask you to confirm a fingerprint before connecting. It will also require the root password for the instance.

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -1,0 +1,2 @@
+"""Extend the core django-simple-deploy CLI to support deployment to VPS instances."""
+

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -4,25 +4,6 @@ class PluginCLI:
     def __init__(self, parser):
         """Extends the CLI for django-simple-deploy."""
 
-        # # Define groups of arguments. These groups help generate a clean
-        # #   output for `manage.py deploy --help`
-        # help_group = parser.add_argument_group("Get help")
-        # required_group = parser.add_argument_group("Required arguments")
-        # behavior_group = parser.add_argument_group(
-        #     "Customize django-simple-deploy's behavior"
-        # )
-        # deployment_config_group = parser.add_argument_group(
-        #     "Customize deployment configuration"
-        # )
-
-        # # Show our own help message.
-        # help_group.add_argument(
-        #     "--help", "-h", action="help", help="Show this help message and exit."
-        # )
-
-
-
-
         parser.add_argument(
             "--ssh-key",
             help="Path to private SSH key for accessing VPS instance.",

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -61,9 +61,8 @@ def _validate_platform(platform):
     if not platform:
         return
 
-    supported_platforms = ["digital_ocean"]
-    if platform not in supported_platforms:
-        msg = f"The platform arg must be one of: {', '.join(supported_platforms)}"
+    if platform not in plugin_config.supported_platforms:
+        msg = f"The platform arg must be one of: {', '.join(plugin_config.supported_platforms)}"
         raise DSDCommandError(msg)
 
 

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -24,6 +24,13 @@ class PluginCLI:
         )
 
         plugin_group.add_argument(
+            "--platform",
+            type=Path,
+            help="Hosting platform, such as digital_ocean.",
+            default=None,
+        )
+
+        plugin_group.add_argument(
             "--ssh-key",
             type=Path,
             help="Path to private SSH key for accessing VPS instance.",
@@ -33,13 +40,32 @@ class PluginCLI:
 
 def validate_cli(options):
     """Validate options that were passed to CLI."""
+    platform = options["platform"]
+    _validate_platform(platform)
+
     ssh_key = options(["ssh_key"])
     if ssh_key is not None:
         path_ssh_key = Path(options["ssh_key"])
         _validate_ssh_key(path_ssh_key)
 
 
+
 # --- Helper functions ---
+
+def _validate_platform(platform):
+    """Validate the --platform arg.
+
+    Should only be used to create initial resources on server in fully automated workflow.
+    """
+    # DEV: If using --automate-all, must specify platform.
+    if not platform:
+        return
+
+    supported_platforms = ["digital_ocean"]
+    if platform not in supported_platforms:
+        msg = f"The platform arg must be one of: {', '.join(supported_platforms)}"
+        raise DSDCommandError(msg)
+
 
 def _validate_ssh_key(path_ssh_key):
     """Validate the ssh key arg that was passed.

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -65,6 +65,9 @@ def _validate_platform(platform):
         msg = f"The platform arg must be one of: {', '.join(plugin_config.supported_platforms)}"
         raise DSDCommandError(msg)
 
+    # --platform arg is valid.
+    plugin_config.platform = platform
+
 
 def _validate_ssh_key(path_ssh_key):
     """Validate the ssh key arg that was passed.

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -1,2 +1,29 @@
 """Extend the core django-simple-deploy CLI to support deployment to VPS instances."""
 
+class PluginCLI:
+    def __init__(self, parser):
+        """Extends the CLI for django-simple-deploy."""
+
+        # # Define groups of arguments. These groups help generate a clean
+        # #   output for `manage.py deploy --help`
+        # help_group = parser.add_argument_group("Get help")
+        # required_group = parser.add_argument_group("Required arguments")
+        # behavior_group = parser.add_argument_group(
+        #     "Customize django-simple-deploy's behavior"
+        # )
+        # deployment_config_group = parser.add_argument_group(
+        #     "Customize deployment configuration"
+        # )
+
+        # # Show our own help message.
+        # help_group.add_argument(
+        #     "--help", "-h", action="help", help="Show this help message and exit."
+        # )
+
+
+
+
+        parser.add_argument(
+            "--ssh-key",
+            help="Path to private SSH key for accessing VPS instance.",
+        )

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -1,10 +1,57 @@
-"""Extend the core django-simple-deploy CLI to support deployment to VPS instances."""
+"""Extends the core django-simple-deploy CLI."""
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+from django_simple_deploy.management.commands.utils.plugin_utils import dsd_config
+from django_simple_deploy.management.commands.utils.command_errors import (
+    DSDCommandError,
+)
+
+from .plugin_config import plugin_config
+
 
 class PluginCLI:
-    def __init__(self, parser):
-        """Extends the CLI for django-simple-deploy."""
 
-        parser.add_argument(
-            "--ssh-key",
-            help="Path to private SSH key for accessing VPS instance.",
+    def __init__(self, parser):
+        """Add plugin-specific args."""
+        group_desc = "Plugin-specific CLI args for dsd-vps"
+        plugin_group = parser.add_argument_group(
+            title="Options for dsd-vps",
+            description = group_desc,
         )
+
+        plugin_group.add_argument(
+            "--ssh-key",
+            type=Path,
+            help="Path to private SSH key for accessing VPS instance.",
+            default=None,
+        )
+
+
+def validate_cli(options):
+    """Validate options that were passed to CLI."""
+    ssh_key = options(["ssh_key"])
+    if ssh_key is not None:
+        path_ssh_key = Path(options["ssh_key"])
+        _validate_ssh_key(path_ssh_key)
+
+
+# --- Helper functions ---
+
+def _validate_ssh_key(path_ssh_key):
+    """Validate the ssh key arg that was passed.
+
+    It's not None if this function is reached.
+    """
+    if dsd_config.unit_testing:
+        return
+
+    if not path_ssh_key.exists():
+        msg = f"The path {path_ssh_key.as_posix()} does not exist."
+        raise DSDCommandError(msg)
+
+    # ssh_key arg is valid. Set the relevant plugin_config attribute.
+    plugin_config.path_ssh_key = path_ssh_key

--- a/dsd_vps/cli.py
+++ b/dsd_vps/cli.py
@@ -25,7 +25,7 @@ class PluginCLI:
 
         plugin_group.add_argument(
             "--platform",
-            type=Path,
+            type=str,
             help="Hosting platform, such as digital_ocean.",
             default=None,
         )
@@ -43,7 +43,7 @@ def validate_cli(options):
     platform = options["platform"]
     _validate_platform(platform)
 
-    ssh_key = options(["ssh_key"])
+    ssh_key = options["ssh_key"]
     if ssh_key is not None:
         path_ssh_key = Path(options["ssh_key"])
         _validate_ssh_key(path_ssh_key)

--- a/dsd_vps/deploy.py
+++ b/dsd_vps/deploy.py
@@ -7,21 +7,26 @@ Notes:
 import django_simple_deploy
 
 from dsd_vps.platform_deployer import PlatformDeployer
-from .plugin_config import PluginConfig
-
-from . import cli
+from .plugin_config import plugin_config
+from .cli import PluginCLI, validate_cli
 
 
 @django_simple_deploy.hookimpl
 def dsd_get_plugin_config():
     """Get platform-specific attributes needed by core."""
-    plugin_config = PluginConfig()
     return plugin_config
 
 
 @django_simple_deploy.hookimpl
-def dsd_get_plugin_cli_args(parser):
-    plugin_cli = cli.PluginCLI(parser)
+def dsd_get_plugin_cli(parser):
+    """Get plugin's CLI extension."""
+    plugin_cli = PluginCLI(parser)
+
+
+@django_simple_deploy.hookimpl
+def dsd_validate_cli(options):
+    """Validate and parse plugin-specific CLI args."""
+    validate_cli(options)
 
 
 @django_simple_deploy.hookimpl

--- a/dsd_vps/deploy.py
+++ b/dsd_vps/deploy.py
@@ -21,10 +21,6 @@ def dsd_get_plugin_config():
 
 @django_simple_deploy.hookimpl
 def dsd_get_plugin_cli_args(parser):
-    # parser.add_argument(
-    #     "--ssh-key",
-    #     help="Path to private SSH key for accessing VPS instance.",
-    # )
     plugin_cli = cli.PluginCLI(parser)
 
 

--- a/dsd_vps/deploy.py
+++ b/dsd_vps/deploy.py
@@ -9,6 +9,8 @@ import django_simple_deploy
 from dsd_vps.platform_deployer import PlatformDeployer
 from .plugin_config import PluginConfig
 
+from . import cli
+
 
 @django_simple_deploy.hookimpl
 def dsd_get_plugin_config():
@@ -19,10 +21,11 @@ def dsd_get_plugin_config():
 
 @django_simple_deploy.hookimpl
 def dsd_get_plugin_cli_args(parser):
-    parser.add_argument(
-        "--ssh-key",
-        help="Path to private SSH key for accessing VPS instance.",
-    )
+    # parser.add_argument(
+    #     "--ssh-key",
+    #     help="Path to private SSH key for accessing VPS instance.",
+    # )
+    plugin_cli = cli.PluginCLI(parser)
 
 
 @django_simple_deploy.hookimpl

--- a/dsd_vps/deploy.py
+++ b/dsd_vps/deploy.py
@@ -18,6 +18,14 @@ def dsd_get_plugin_config():
 
 
 @django_simple_deploy.hookimpl
+def dsd_get_plugin_cli_args(parser):
+    parser.add_argument(
+        "--ssh-key",
+        help="Path to private SSH key for accessing VPS instance.",
+    )
+
+
+@django_simple_deploy.hookimpl
 def dsd_deploy():
     """Carry out platform-specific deployment steps."""
     platform_deployer = PlatformDeployer()

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -87,40 +87,81 @@ class PlatformDeployer:
 
             # Make a new droplet, and get droplet ID.
             cmd = "doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json"
-            output = plugin_utils.run_quick_command(cmd)
+            output = plugin_utils.run_quick_command(cmd).stdout.decode()
             plugin_utils.write_output(output)
 
             output_json = json.loads(output)
             plugin_config.droplet_id = output_json[0]["id"]
 
             msg = f"  Droplet ID: {plugin_config.droplet_id}"
+            plugin_utils.write_output(msg)
 
             # Sleep 3 seconds to let droplet spin up.
-            plugin_utils.write_output("  Sleeping to let droplet spin up...")
-            time.sleep(3)
+            pause = 10
+            plugin_utils.write_output(f"    Sleeping {pause} seconds to let droplet spin up...")
+            time.sleep(pause)
 
             # Get IP address of new droplet.
-            plugin_config.ip_address = None
+            # plugin_config.ip_address = None
+            droplet_status = "new"
             num_tries = 0
-            while not plugin_config.ip_address and num_tries < 5:
-                plugin_utils.write_output("  Querying for ip_address...")
+            while droplet_status == "new" and num_tries < 10:
+                plugin_utils.write_output("    Querying for ip_address...")
 
                 cmd = f"doctl compute droplet get {plugin_config.droplet_id} -o json"
-                output = plugin_utils.run_quick_command(cmd)
+                output = plugin_utils.run_quick_command(cmd).stdout.decode()
                 output_json = json.loads(output)
 
-                if output_json[0]["status"] == "new":
-                    time.sleep(1)
+                droplet_status = output_json[0]["status"]
+
+                if droplet_status == "new":
+                    time.sleep(5)
                     num_tries += 1
-                    continue
-                else:
-                    # ip address should be available
-                    plugin_config.ip_address = output_json[0]["networks"]["v4"][0]["ip_address"]
-                    plugin_utils.write_output(f"  IP address: {plugin_config.ip_address}")
+                
+            # ip address should be available
+            # There are two, and they haven't been in a consistent order.
+            # We're looking to the ip address starting with 3 digits.
+            ip_addresses = [
+                network_dict["ip_address"]
+                for network_dict in output_json[0]["networks"]["v4"]
+            ]
+
+            for ip_address in ip_addresses:
+                if len(ip_address.split(".")[0]) == 3:
+                    plugin_config.ip_address = ip_address
+                    break
 
             if not plugin_config.ip_address:
-                msg = f"Could not find ip_address. Tried {num_tries} times."
+                msg = "Could not identify IP address."
                 raise DSDCommandError(msg)
+
+            msg = f"  IP address: {plugin_config.ip_address}"
+            plugin_utils.write_output(msg)
+
+
+            # ip_address = None
+            # for network_dict in output_json[0]["networks"]["v4"]:
+            #     ip_address = network_dict["ip_address"]
+            #     if len(ip_address.split(".")[0]) == 3:
+            #         break
+
+            # if ip_address:
+            #     plugin_config.ip_address = ip_address
+            # else:
+            #     msg = 
+
+
+
+
+
+            #         plugin_config.ip_address = output_json[0]["networks"]["v4"][0]["ip_address"]
+            #         plugin_utils.write_output(f"  IP address: {plugin_config.ip_address}")
+
+            # if not plugin_config.ip_address:
+            #     msg = f"Could not find ip_address. Tried {num_tries} times."
+            #     raise DSDCommandError(msg)
+
+            breakpoint()
 
 
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -102,7 +102,6 @@ class PlatformDeployer:
             time.sleep(pause)
 
             # Get IP address of new droplet.
-            # plugin_config.ip_address = None
             droplet_status = "new"
             num_tries = 0
             while droplet_status == "new" and num_tries < 10:
@@ -118,9 +117,9 @@ class PlatformDeployer:
                     time.sleep(5)
                     num_tries += 1
                 
-            # ip address should be available
+            # IP address should be available
             # There are two, and they haven't been in a consistent order.
-            # We're looking to the ip address starting with 3 digits.
+            # We're looking for the IP address starting with 3 digits.
             ip_addresses = [
                 network_dict["ip_address"]
                 for network_dict in output_json[0]["networks"]["v4"]
@@ -137,34 +136,6 @@ class PlatformDeployer:
 
             msg = f"  IP address: {plugin_config.ip_address}"
             plugin_utils.write_output(msg)
-
-
-            # ip_address = None
-            # for network_dict in output_json[0]["networks"]["v4"]:
-            #     ip_address = network_dict["ip_address"]
-            #     if len(ip_address.split(".")[0]) == 3:
-            #         break
-
-            # if ip_address:
-            #     plugin_config.ip_address = ip_address
-            # else:
-            #     msg = 
-
-
-
-
-
-            #         plugin_config.ip_address = output_json[0]["networks"]["v4"][0]["ip_address"]
-            #         plugin_utils.write_output(f"  IP address: {plugin_config.ip_address}")
-
-            # if not plugin_config.ip_address:
-            #     msg = f"Could not find ip_address. Tried {num_tries} times."
-            #     raise DSDCommandError(msg)
-
-            breakpoint()
-
-
-
 
 
     def _connect_server(self):

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -112,6 +112,7 @@ class PlatformDeployer:
 
                 cmd = f"doctl compute droplet get {plugin_config.droplet_id} -o json"
                 output = plugin_utils.run_quick_command(cmd).stdout.decode()
+                plugin_utils.write_output(output, write_to_console=False)
                 output_json = json.loads(output)
 
                 droplet_status = output_json[0]["status"]
@@ -120,17 +121,13 @@ class PlatformDeployer:
                     time.sleep(5)
                     num_tries += 1
                 
-            # IP address should be available
+            # Public IP address should be available
             # There are two, and they haven't been in a consistent order.
             # We're looking for the IP address starting with 3 digits.
-            ip_addresses = [
-                network_dict["ip_address"]
-                for network_dict in output_json[0]["networks"]["v4"]
-            ]
-
-            for ip_address in ip_addresses:
-                if len(ip_address.split(".")[0]) == 3:
-                    plugin_config.ip_address = ip_address
+            network_dicts = output_json[0]["networks"]["v4"]
+            for network_dict in network_dicts:
+                if network_dict["type"] == "public":
+                    plugin_config.ip_address = network_dict["ip_address"]
                     break
 
             if not plugin_config.ip_address:
@@ -143,8 +140,8 @@ class PlatformDeployer:
 
     def _connect_server(self):
         """Make sure we can connect to the server, with an appropriate username."""
-        breakpoint()
         do_utils.set_server_username()
+        breakpoint()
         do_utils.configure_firewall()
 
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -140,7 +140,6 @@ class PlatformDeployer:
 
     def _connect_server(self):
         """Make sure we can connect to the server, with an appropriate username."""
-        breakpoint()
         do_utils.set_server_username()
         do_utils.configure_firewall()
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -89,7 +89,7 @@ class PlatformDeployer:
             do_utils.get_ssh_key_ids_digitalocean()
 
             # Make a new droplet, and get droplet ID.
-            cmd = f"doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json --ssh-keys {plugin_config.path_ssh_key.as_posix()}"
+            cmd = f"doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json --ssh-keys {plugin_config.ssh_key_id}"
             output = plugin_utils.run_quick_command(cmd).stdout.decode()
             plugin_utils.write_output(output, write_to_console=False)
 
@@ -143,6 +143,7 @@ class PlatformDeployer:
 
     def _connect_server(self):
         """Make sure we can connect to the server, with an appropriate username."""
+        breakpoint()
         do_utils.set_server_username()
         do_utils.configure_firewall()
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -330,7 +330,10 @@ class PlatformDeployer:
         do_utils.serve_project()
 
         # Should set self.deployed_url, which will be reported in the success message.
-        self.deployed_url = f"http://{os.environ.get('DSD_HOST_IPADDR')}/"
+        if plugin_config.path_ssh_key:
+            self.deployed_url = f"http://{plugin_config.ip_address}/"
+        else:
+            self.deployed_url = f"http://{os.environ.get('DSD_HOST_IPADDR')}/"
         webbrowser.open(self.deployed_url)
 
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -46,12 +46,6 @@ class PlatformDeployer:
 
         # Configure server.
         self._connect_server()
-
-        # DEV: Try doing this before updating server, so confirmations happen early.
-        do_utils.configure_git(self.templates_path)
-
-
-        
         self._update_server()
         self._setup_server()
         
@@ -176,13 +170,9 @@ class PlatformDeployer:
         - https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu
         """
         # DEV: Disable during development.
-
-        # DEV: Try configuring git before updating server.
-        # do_utils.configure_git(self.templates_path)
-
-
         do_utils.install_uv()
         do_utils.install_python()
+        do_utils.configure_git(self.templates_path)
         do_utils.install_caddy()
 
     def _add_requirements(self):

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -141,7 +141,6 @@ class PlatformDeployer:
     def _connect_server(self):
         """Make sure we can connect to the server, with an appropriate username."""
         do_utils.set_server_username()
-        breakpoint()
         do_utils.configure_firewall()
 
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -86,7 +86,7 @@ class PlatformDeployer:
             plugin_utils.write_output("Creating droplet on Digital Ocean...")
 
             # Get SSH key ID.
-            plugin_config.ssh_key_id = do_utils.get_ssh_key_ids_digitalocean()
+            do_utils.get_ssh_key_ids_digitalocean()
 
             # Make a new droplet, and get droplet ID.
             cmd = f"doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json --ssh-keys {plugin_config.path_ssh_key.as_posix()}"

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -74,7 +74,13 @@ class PlatformDeployer:
 
     def _prep_automate_all(self):
         """Take any further actions needed if using automate_all."""
-        pass
+        if not plugin_config.platform:
+            msg = "You must specify a --platform in order to use --automate-all."
+        if plugin_config.platform == "digital_ocean":
+            # Make a new droplet, and get droplet ID.
+            pass
+
+            # Get IP address of new droplet.
 
 
     def _connect_server(self):

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -16,6 +16,7 @@ from django.utils.safestring import mark_safe
 
 import requests
 
+from .plugin_config import plugin_config
 from . import deploy_messages as platform_msgs
 from . import utils as do_utils
 
@@ -74,6 +75,9 @@ class PlatformDeployer:
 
     def _prep_automate_all(self):
         """Take any further actions needed if using automate_all."""
+        if not dsd_config.automate_all:
+            return
+            
         if not plugin_config.platform:
             msg = "You must specify a --platform in order to use --automate-all."
         if plugin_config.platform == "digital_ocean":

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -85,8 +85,11 @@ class PlatformDeployer:
         if plugin_config.platform == "digital_ocean":
             plugin_utils.write_output("Creating droplet on Digital Ocean...")
 
+            # Get SSH key ID.
+            plugin_config.ssh_key_id = do_utils.get_ssh_key_ids_digitalocean()
+
             # Make a new droplet, and get droplet ID.
-            cmd = "doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json"
+            cmd = f"doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json --ssh-keys {plugin_config.path_ssh_key.as_posix()}"
             output = plugin_utils.run_quick_command(cmd).stdout.decode()
             plugin_utils.write_output(output, write_to_console=False)
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -46,6 +46,12 @@ class PlatformDeployer:
 
         # Configure server.
         self._connect_server()
+
+        # DEV: Try doing this before updating server, so confirmations happen early.
+        do_utils.configure_git(self.templates_path)
+
+
+        
         self._update_server()
         self._setup_server()
         
@@ -170,9 +176,13 @@ class PlatformDeployer:
         - https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu
         """
         # DEV: Disable during development.
+
+        # DEV: Try configuring git before updating server.
+        # do_utils.configure_git(self.templates_path)
+
+
         do_utils.install_uv()
         do_utils.install_python()
-        do_utils.configure_git(self.templates_path)
         do_utils.install_caddy()
 
     def _add_requirements(self):

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -77,12 +77,23 @@ class PlatformDeployer:
         """Take any further actions needed if using automate_all."""
         if not dsd_config.automate_all:
             return
-            
+
         if not plugin_config.platform:
             msg = "You must specify a --platform in order to use --automate-all."
+            raise DSDCommandError(msg)
+
         if plugin_config.platform == "digital_ocean":
+            plugin_utils.write_output("Creating droplet on Digital Ocean...")
+
             # Make a new droplet, and get droplet ID.
-            pass
+            cmd = "doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json"
+            output = plugin_utils.run_quick_command(cmd)
+
+            output_json = json.loads(output)
+            id_droplet = output_json[0]["id"]
+
+            plugin_utils.write_output(output)
+
 
             # Get IP address of new droplet.
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -223,6 +223,8 @@ class PlatformDeployer:
         template_path = self.templates_path / "Caddyfile"
         if dsd_config.unit_testing:
             context = {"server_ip_address": None}
+        elif plugin_config.path_ssh_key:
+            context = {"server_ip_address": plugin_config.ip_address}
         else:
             context = {"server_ip_address": os.environ.get("DSD_HOST_IPADDR")}
         contents = plugin_utils.get_template_string(template_path, context)

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -140,6 +140,7 @@ class PlatformDeployer:
 
     def _connect_server(self):
         """Make sure we can connect to the server, with an appropriate username."""
+        breakpoint()
         do_utils.set_server_username()
         do_utils.configure_firewall()
 

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -88,14 +88,42 @@ class PlatformDeployer:
             # Make a new droplet, and get droplet ID.
             cmd = "doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json"
             output = plugin_utils.run_quick_command(cmd)
-
-            output_json = json.loads(output)
-            id_droplet = output_json[0]["id"]
-
             plugin_utils.write_output(output)
 
+            output_json = json.loads(output)
+            plugin_config.droplet_id = output_json[0]["id"]
+
+            msg = f"  Droplet ID: {plugin_config.droplet_id}"
+
+            # Sleep 3 seconds to let droplet spin up.
+            plugin_utils.write_output("  Sleeping to let droplet spin up...")
+            time.sleep(3)
 
             # Get IP address of new droplet.
+            plugin_config.ip_address = None
+            num_tries = 0
+            while not plugin_config.ip_address and num_tries < 5:
+                plugin_utils.write_output("  Querying for ip_address...")
+
+                cmd = f"doctl compute droplet get {plugin_config.droplet_id} -o json"
+                output = plugin_utils.run_quick_command(cmd)
+                output_json = json.loads(output)
+
+                if output_json[0]["status"] == "new":
+                    time.sleep(1)
+                    num_tries += 1
+                    continue
+                else:
+                    # ip address should be available
+                    plugin_config.ip_address = output_json[0]["networks"]["v4"][0]["ip_address"]
+                    plugin_utils.write_output(f"  IP address: {plugin_config.ip_address}")
+
+            if not plugin_config.ip_address:
+                msg = f"Could not find ip_address. Tried {num_tries} times."
+                raise DSDCommandError(msg)
+
+
+
 
 
     def _connect_server(self):

--- a/dsd_vps/platform_deployer.py
+++ b/dsd_vps/platform_deployer.py
@@ -88,7 +88,7 @@ class PlatformDeployer:
             # Make a new droplet, and get droplet ID.
             cmd = "doctl compute droplet create dsd-e2e-test --image ubuntu-25-04-x64 --size s-1vcpu-1gb --region nyc3 -o json"
             output = plugin_utils.run_quick_command(cmd).stdout.decode()
-            plugin_utils.write_output(output)
+            plugin_utils.write_output(output, write_to_console=False)
 
             output_json = json.loads(output)
             plugin_config.droplet_id = output_json[0]["id"]

--- a/dsd_vps/plugin_config.py
+++ b/dsd_vps/plugin_config.py
@@ -26,7 +26,10 @@ class PluginConfig:
         self.confirm_automate_all_msg = platform_msgs.confirm_automate_all
         self.platform_name = "VPS"
 
+        self.platform = None
         self.supported_platforms = ["digital_ocean"]
+
+        self.ip_address = None
 
 # Create plugin_config once right here. This approach keeps from having to pass the config
 # instance between core, plugins, and these utility functions.

--- a/dsd_vps/plugin_config.py
+++ b/dsd_vps/plugin_config.py
@@ -25,3 +25,7 @@ class PluginConfig:
         self.automate_all_supported = True
         self.confirm_automate_all_msg = platform_msgs.confirm_automate_all
         self.platform_name = "VPS"
+
+# Create plugin_config once right here. This approach keeps from having to pass the config
+# instance between core, plugins, and these utility functions.
+plugin_config = PluginConfig()

--- a/dsd_vps/plugin_config.py
+++ b/dsd_vps/plugin_config.py
@@ -26,6 +26,8 @@ class PluginConfig:
         self.confirm_automate_all_msg = platform_msgs.confirm_automate_all
         self.platform_name = "VPS"
 
+        self.supported_platforms = ["digital_ocean"]
+
 # Create plugin_config once right here. This approach keeps from having to pass the config
 # instance between core, plugins, and these utility functions.
 plugin_config = PluginConfig()

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -35,6 +35,10 @@ def get_ssh_key_ids_digitalocean():
             msg = "Can't proceed without an SSH key id."
             raise DSDCommandError(msg)
 
+    # Show keys, in a call to plugin_utils.get_numbered_choice().
+
+
+    # If appropriate, offer to generate a new key.
 
 
 

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -339,6 +339,12 @@ def add_server_user():
         plugin_utils.write_output("  Setting password; will not display or log this.")
         cmd = f'echo "{django_username}:{password}" | chpasswd'
         run_server_cmd_ssh(cmd, show_output=False, skip_logging=True)
+    else:
+        plugin_utils.write_output("  Setting password; will not display or log this.")
+        # DEV: Simple pw for development work.
+        password = "django_user"
+        cmd = f'echo "{django_username}:{password}" | chpasswd'
+        run_server_cmd_ssh(cmd, show_output=False, skip_logging=True)
 
     if plugin_config.path_ssh_key:
         # Copy ssh keys for this user.

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -354,28 +354,31 @@ def configure_git(templates_path):
         return
 
     # Configure ssh keys, so push can happen without prompting for password.
-    # Generate key pair.
-    ipaddr = os.environ.get("DSD_HOST_IPADDR")
-    path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
-    if path_keyfile.exists():
-        raise DSDCommandError(f"Git ssh keyfile already exists at {path_keyfile}.")
+    if plugin_config.path_ssh_key:
+        ipaddr = plugin_config.ip_address
+    else:
+        # Generate key pair.
+        ipaddr = os.environ.get("DSD_HOST_IPADDR")
+        path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
+        if path_keyfile.exists():
+            raise DSDCommandError(f"Git ssh keyfile already exists at {path_keyfile}.")
 
-    cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
-    output_obj = plugin_utils.run_quick_command(cmd)
-    stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
-    plugin_utils.write_output(stdout)
-    if stderr:
-        plugin_utils.write_output("--- Error ---")
-        plugin_utils.write_output(stderr)
+        cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
+        output_obj = plugin_utils.run_quick_command(cmd)
+        stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
+        plugin_utils.write_output(stdout)
+        if stderr:
+            plugin_utils.write_output("--- Error ---")
+            plugin_utils.write_output(stderr)
 
-    # Copy key to server.
-    cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
-    output_obj = plugin_utils.run_quick_command(cmd)
-    stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
-    plugin_utils.write_output(stdout)
-    if stderr:
-        plugin_utils.write_output("--- Error ---")
-        plugin_utils.write_output(stderr)
+        # Copy key to server.
+        cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
+        output_obj = plugin_utils.run_quick_command(cmd)
+        stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
+        plugin_utils.write_output(stdout)
+        if stderr:
+            plugin_utils.write_output("--- Error ---")
+            plugin_utils.write_output(stderr)
 
     # Add ssh config to end of config file, if not already present.
     template_path = templates_path / "git_ssh_config_block.txt"

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -239,7 +239,7 @@ def set_server_username():
     dsd_config.server_username = "django_user"
     try:
         run_server_cmd_ssh("uptime", timeout=3)
-    except (paramiko.ssh_exception.AuthenticationException, paramiko.ssh_exception.SSHException, AttributeError):
+    except (paramiko.ssh_exception.AuthenticationException, paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, AttributeError, TimeoutError):
         # Default non-root user doesn't exist.
         dsd_config.server_username = "root"
         plugin_utils.write_output("  Using root for now...")
@@ -398,32 +398,33 @@ def configure_git(templates_path):
     if dsd_config.unit_testing:
         return
 
-    # Configure ssh keys, so push can happen without prompting for password.
     if plugin_config.path_ssh_key:
         ipaddr = plugin_config.ip_address
     else:
-        # Generate key pair.
         ipaddr = os.environ.get("DSD_HOST_IPADDR")
-        path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
-        if path_keyfile.exists():
-            raise DSDCommandError(f"Git ssh keyfile already exists at {path_keyfile}.")
 
-        cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
-        output_obj = plugin_utils.run_quick_command(cmd)
-        stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
-        plugin_utils.write_output(stdout)
-        if stderr:
-            plugin_utils.write_output("--- Error ---")
-            plugin_utils.write_output(stderr)
+    # Configure ssh keys, so push can happen without prompting for password.
+    # Generate key pair.
+    path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
+    if path_keyfile.exists():
+        raise DSDCommandError(f"Git ssh keyfile already exists at {path_keyfile}.")
 
-        # Copy key to server.
-        cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
-        output_obj = plugin_utils.run_quick_command(cmd)
-        stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
-        plugin_utils.write_output(stdout)
-        if stderr:
-            plugin_utils.write_output("--- Error ---")
-            plugin_utils.write_output(stderr)
+    cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
+    output_obj = plugin_utils.run_quick_command(cmd)
+    stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
+    plugin_utils.write_output(stdout)
+    if stderr:
+        plugin_utils.write_output("--- Error ---")
+        plugin_utils.write_output(stderr)
+
+    # Copy key to server.
+    cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
+    output_obj = plugin_utils.run_quick_command(cmd)
+    stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
+    plugin_utils.write_output(stdout)
+    if stderr:
+        plugin_utils.write_output("--- Error ---")
+        plugin_utils.write_output(stderr)
 
     # Add ssh config to end of config file, if not already present.
     template_path = templates_path / "git_ssh_config_block.txt"

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -426,7 +426,7 @@ def configure_git(templates_path):
 
     # Copy key to server.
     if plugin_config.path_ssh_key:
-        cmd = f"ssh-copy-id -f -i {path_keyfile.as_posix()} -o IdentityFile={plugin_config.path_ssh_key} {dsd_config.server_username}@{plugin_config.ip_address}"
+        cmd = f"ssh-copy-id -f -i {path_keyfile.as_posix()} -o IdentityFile={plugin_config.path_ssh_key} {dsd_config.server_username}@{plugin_config.ip_address} -o StrictHostKeyChecking=accept-new"
     else:
         cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
     output_obj = plugin_utils.run_quick_command(cmd)

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -1,5 +1,6 @@
 """Utilities specific to deploying to a VPS."""
 
+import json
 import os
 import time
 from pathlib import Path
@@ -10,6 +11,32 @@ from paramiko.ssh_exception import NoValidConnectionsError
 from django_simple_deploy.management.commands.utils import plugin_utils
 from django_simple_deploy.management.commands.utils.plugin_utils import dsd_config
 from django_simple_deploy.management.commands.utils.command_errors import DSDCommandError
+
+from .plugin_config import plugin_config
+
+
+def get_ssh_key_ids_digitalocean():
+    """Get any existing ssh key IDs on Digital Ocean."""
+    cmd = "doctl compute ssh-key list -o json"
+    output = plugin_utils.run_quick_command(cmd, skip_logging=True).stdout.decode()
+    key_dicts = json.loads(output)
+
+    ssh_key_ids = [key_dict["id"] for key_dict in key_dicts]
+
+    if len(ssh_key_ids) == 1:
+        ssh_key_id = ssh_key_ids[0]
+        key_name = key_dicts[0]["name"]
+        msg = f"\nWould you like to use the DO ssh key ID {ssh_key_id}, from the key {key_name}? "
+        proceed = plugin_utils.get_confirmation(msg, skip_logging=True)
+
+        if proceed:
+            return ssh_key_id
+        else:
+            msg = "Can't proceed without an SSH key id."
+            raise DSDCommandError(msg)
+
+
+
 
 
 def run_server_cmd_ssh(cmd, timeout=10, show_output=True, skip_logging=None):
@@ -36,6 +63,7 @@ def run_server_cmd_ssh(cmd, timeout=10, show_output=True, skip_logging=None):
     # Get client.
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    breakpoint()
 
     # Run command, and close connection.
     try:

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -68,20 +68,44 @@ def run_server_cmd_ssh(cmd, timeout=10, show_output=True, skip_logging=None):
     # Get client.
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    breakpoint()
 
     # Run command, and close connection.
     try:
-        client.connect(
-            hostname = os.environ.get("DSD_HOST_IPADDR"),
-            username = dsd_config.server_username,
-            password = os.environ.get("DSD_HOST_PW"),
-            timeout = timeout
-        )
-        _stdin, _stdout, _stderr = client.exec_command(cmd)
+        if plugin_config.path_ssh_key:
+            num_tries = 0
+            pause = 20
+            while num_tries < 10:
+                try:
+                    plugin_utils.write_output("    Trying to connect using ssh key...")
+                    client.connect(
+                        hostname = plugin_config.ip_address,
+                        username = "root",
+                        key_filename = plugin_config.path_ssh_key.as_posix(),
+                        timeout = timeout
+                    )
+                except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError) as e:
+                    plugin_utils.write_output(str(e))
+                    plugin_utils.write_output(f"      Attempt failed, waiting {pause}s...")
+                    time.sleep(pause)
+                    num_tries += 1
+                else:
+                    break
 
-        stdout = _stdout.read().decode().strip()
-        stderr = _stderr.read().decode().strip()
+            _stdin, _stdout, _stderr = client.exec_command(cmd)
+
+            stdout = _stdout.read().decode().strip()
+            stderr = _stderr.read().decode().strip()
+        else:
+            client.connect(
+                hostname = os.environ.get("DSD_HOST_IPADDR"),
+                username = dsd_config.server_username,
+                password = os.environ.get("DSD_HOST_PW"),
+                timeout = timeout
+            )
+            _stdin, _stdout, _stderr = client.exec_command(cmd)
+
+            stdout = _stdout.read().decode().strip()
+            stderr = _stderr.read().decode().strip()
     finally:
         client.close()
 
@@ -174,8 +198,15 @@ def set_server_username():
         plugin_utils.write_output(f"  username: {username}")
         return
 
-    # No custom username. Try to connect with default username.
+    # No custom username. Use "django_user" from this point forward.
     dsd_config.server_username = "django_user"
+
+    # If using ssh keys, create django_user in case they don't exist..
+    if plugin_config.path_ssh_key:
+        add_server_user()
+        plugin_utils.write_output(f"  username: {dsd_config.server_username}")
+
+    # No custom username, and not using ssh keys. Try to connect with default username.
     try:
         run_server_cmd_ssh("uptime")
     except paramiko.ssh_exception.AuthenticationException:
@@ -268,7 +299,10 @@ def add_server_user():
     django_username = "django_user"
     plugin_utils.write_output(f"Adding non-root user: {django_username}")
     cmd = f"useradd -m {django_username}"
-    run_server_cmd_ssh(cmd)
+    stdout, stderr = run_server_cmd_ssh(cmd)
+
+    if "already exists" in stderr:
+        return
 
     # Set the password.
     plugin_utils.write_output("  Setting password; will not display or log this.")

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -44,7 +44,7 @@ def get_ssh_key_ids_digitalocean():
 
 
 
-def run_server_cmd_ssh(cmd, timeout=10, show_output=True, skip_logging=None):
+def run_server_cmd_ssh(cmd, timeout=10, max_tries=3, pause=3, show_output=True, skip_logging=None):
     """Run a command on the server, through an SSH connection.
 
     Returns:
@@ -73,13 +73,12 @@ def run_server_cmd_ssh(cmd, timeout=10, show_output=True, skip_logging=None):
     try:
         if plugin_config.path_ssh_key:
             num_tries = 0
-            pause = 20
-            while num_tries < 10:
+            while num_tries < max_tries:
                 try:
                     plugin_utils.write_output("    Trying to connect using ssh key...")
                     client.connect(
                         hostname = plugin_config.ip_address,
-                        username = "root",
+                        username = dsd_config.server_username,
                         key_filename = plugin_config.path_ssh_key.as_posix(),
                         timeout = timeout
                     )
@@ -223,18 +222,19 @@ def set_server_username():
         plugin_utils.write_output(f"  username: {username}")
         return
 
-    # No custom username. Use "django_user" from this point forward.
+    # # If using ssh keys, create django_user in case they don't exist..
+    # if plugin_config.path_ssh_key:
+    #     dsd_config.
+    #     add_server_user()
+    #     plugin_utils.write_output(f"  username: {dsd_config.server_username}")
+    #     return
+
+    # Using un/pw connection, not ssh keys.
+    # Use "django_user" from this point forward. Try to connect with this default username.
     dsd_config.server_username = "django_user"
-
-    # If using ssh keys, create django_user in case they don't exist..
-    if plugin_config.path_ssh_key:
-        add_server_user()
-        plugin_utils.write_output(f"  username: {dsd_config.server_username}")
-
-    # No custom username, and not using ssh keys. Try to connect with default username.
     try:
-        run_server_cmd_ssh("uptime")
-    except paramiko.ssh_exception.AuthenticationException:
+        run_server_cmd_ssh("uptime", timeout=3)
+    except (paramiko.ssh_exception.AuthenticationException, paramiko.ssh_exception.SSHException, AttributeError):
         # Default non-root user doesn't exist.
         dsd_config.server_username = "root"
         plugin_utils.write_output("  Using root for now...")
@@ -332,6 +332,10 @@ def add_server_user():
     # Set the password.
     plugin_utils.write_output("  Setting password; will not display or log this.")
     password = os.environ.get("DSD_HOST_PW")
+    if not password:
+        prompt = "\n\nWhat password would you like to set for django_user? "
+        password = input(prompt)
+
     cmd = f'echo "{django_username}:{password}" | chpasswd'
     run_server_cmd_ssh(cmd, show_output=False, skip_logging=True)
 

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -406,16 +406,14 @@ def configure_git(templates_path):
     # Configure ssh keys, so push can happen without prompting for password.
     # Generate key pair.
     path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
-    if path_keyfile.exists():
-        raise DSDCommandError(f"Git ssh keyfile already exists at {path_keyfile}.")
-
-    cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
-    output_obj = plugin_utils.run_quick_command(cmd)
-    stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
-    plugin_utils.write_output(stdout)
-    if stderr:
-        plugin_utils.write_output("--- Error ---")
-        plugin_utils.write_output(stderr)
+    if not path_keyfile.exists():
+        cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
+        output_obj = plugin_utils.run_quick_command(cmd)
+        stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
+        plugin_utils.write_output(stdout)
+        if stderr:
+            plugin_utils.write_output("--- Error ---")
+            plugin_utils.write_output(stderr)
 
     # Copy key to server.
     cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -84,9 +84,14 @@ def run_server_cmd_ssh(cmd, timeout=10, max_tries=3, pause=3, show_output=True, 
                     )
                 except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError) as e:
                     plugin_utils.write_output(str(e))
-                    plugin_utils.write_output(f"      Attempt failed, waiting {pause}s...")
-                    time.sleep(pause)
+                    plugin_utils.write_output("      Attempt failed.")
                     num_tries += 1
+
+                    if num_tries == max_tries:
+                        raise e
+                    else:
+                        print(f"     Waiting {pause}s...")
+                        time.sleep(pause)
                 else:
                     break
 
@@ -330,14 +335,25 @@ def add_server_user():
         return
 
     # Set the password.
-    plugin_utils.write_output("  Setting password; will not display or log this.")
-    password = os.environ.get("DSD_HOST_PW")
-    if not password:
-        prompt = "\n\nWhat password would you like to set for django_user? "
-        password = input(prompt)
+    if password := os.environ.get("DSD_HOST_PW"):
+        plugin_utils.write_output("  Setting password; will not display or log this.")
+        cmd = f'echo "{django_username}:{password}" | chpasswd'
+        run_server_cmd_ssh(cmd, show_output=False, skip_logging=True)
 
-    cmd = f'echo "{django_username}:{password}" | chpasswd'
-    run_server_cmd_ssh(cmd, show_output=False, skip_logging=True)
+    if plugin_config.path_ssh_key:
+        # Copy ssh keys for this user.
+        # Make ~/.ssh
+        cmd = f"mkdir /home/{django_username}/.ssh"
+        output = run_server_cmd_ssh(cmd)
+
+        # Copy keys.
+        cmd = f"cp /root/.ssh/authorized_keys /home/{django_username}/.ssh/authorized_keys"
+        output = run_server_cmd_ssh(cmd)
+
+        # Set ownership.
+        cmd = f"chown -R {django_username}:{django_username} /home/{django_username}/.ssh"
+        output = run_server_cmd_ssh(cmd)
+
 
     # Add user to sudo group.
     plugin_utils.write_output("  Adding user to sudo group.")

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -82,7 +82,7 @@ def run_server_cmd_ssh(cmd, timeout=10, max_tries=3, pause=3, show_output=True, 
                         key_filename = plugin_config.path_ssh_key.as_posix(),
                         timeout = timeout
                     )
-                except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError) as e:
+                except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError, ConnectionResetError) as e:
                     plugin_utils.write_output(str(e))
                     plugin_utils.write_output("      Attempt failed.")
                     num_tries += 1
@@ -157,7 +157,7 @@ def copy_to_server(path_local, path_remote, timeout=10, skip_logging=None):
                     key_filename = plugin_config.path_ssh_key.as_posix(),
                     timeout = timeout
                 )
-            except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError) as e:
+            except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError, ConnectionResetError) as e:
                 plugin_utils.write_output(str(e))
                 plugin_utils.write_output(f"      Attempt failed, waiting {pause}s...")
                 time.sleep(pause)

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -30,7 +30,7 @@ def get_ssh_key_ids_digitalocean():
         proceed = plugin_utils.get_confirmation(msg, skip_logging=True)
 
         if proceed:
-            plugin_utils.ssh_key_id = ssh_key_id
+            plugin_config.ssh_key_id = ssh_key_id
             return
         else:
             msg = "Can't proceed without an SSH key id."

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -93,6 +93,7 @@ def run_server_cmd_ssh(cmd, timeout=10, max_tries=3, pause=3, show_output=True, 
                         print(f"     Waiting {pause}s...")
                         time.sleep(pause)
                 else:
+                    plugin_utils.write_output("      Connection successful, running command.")
                     break
 
             _stdin, _stdout, _stderr = client.exec_command(cmd)
@@ -162,6 +163,7 @@ def copy_to_server(path_local, path_remote, timeout=10, skip_logging=None):
                 time.sleep(pause)
                 num_tries += 1
             else:
+                plugin_utils.write_output("      Connection successful, running command.")
                 break
 
         sftp = client.open_sftp()

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -415,6 +415,7 @@ def configure_git(templates_path):
     # Generate key pair.
     path_keyfile = Path.home() / ".ssh" / "id_rsa_git"
     if not path_keyfile.exists():
+        plugin_utils.write_output("  Generating ssh keys...")
         cmd = f'ssh-keygen -t rsa -b 4096 -C "{dsd_config.server_username}@{ipaddr}" -f {path_keyfile.as_posix()} -N ""'
         output_obj = plugin_utils.run_quick_command(cmd)
         stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
@@ -456,6 +457,7 @@ def configure_git(templates_path):
 
     # Make a project directory.
     cmd = f"mkdir -p {project_path}"
+    breakpoint()
     run_server_cmd_ssh(cmd)
 
     cmd = f"chown -R {dsd_config.server_username}:{dsd_config.server_username} {project_path}"

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -140,18 +140,43 @@ def copy_to_server(path_local, path_remote, timeout=10, skip_logging=None):
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     # Copy file, and close connection.
-    try:
-        client.connect(
-            hostname = os.environ.get("DSD_HOST_IPADDR"),
-            username = dsd_config.server_username,
-            password = os.environ.get("DSD_HOST_PW"),
-            timeout = timeout
-        )
+    if plugin_config.path_ssh_key:
+        num_tries = 0
+        pause = 20
+        while num_tries < 10:
+            try:
+                plugin_utils.write_output("    Trying to connect using ssh key...")
+                client.connect(
+                    hostname = plugin_config.ip_address,
+                    username = dsd_config.server_username,
+                    key_filename = plugin_config.path_ssh_key.as_posix(),
+                    timeout = timeout
+                )
+            except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError, TimeoutError) as e:
+                plugin_utils.write_output(str(e))
+                plugin_utils.write_output(f"      Attempt failed, waiting {pause}s...")
+                time.sleep(pause)
+                num_tries += 1
+            else:
+                break
+
         sftp = client.open_sftp()
         sftp.put(path_local, path_remote)
         sftp.close()
-    finally:
         client.close()
+    else:
+        try:
+            client.connect(
+                hostname = os.environ.get("DSD_HOST_IPADDR"),
+                username = dsd_config.server_username,
+                password = os.environ.get("DSD_HOST_PW"),
+                timeout = timeout
+            )
+            sftp = client.open_sftp()
+            sftp.put(path_local, path_remote)
+            sftp.close()
+        finally:
+            client.close()
 
 
 

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -426,7 +426,7 @@ def configure_git(templates_path):
 
     # Copy key to server.
     if plugin_config.path_ssh_key:
-        cmd = f"ssh-copy-id -f -i {path_keyfile.as_posix()} -o IdentityFile={plugin_config.path_ssh_key} {dsd_config.server_username}@{plugin_config.ip_address} -o StrictHostKeyChecking=accept-new"
+        cmd = f"ssh-copy-id -f -i {path_keyfile.as_posix()} -o StrictHostKeyChecking=accept-new -o IdentityFile={plugin_config.path_ssh_key} {dsd_config.server_username}@{plugin_config.ip_address}"
     else:
         cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
     output_obj = plugin_utils.run_quick_command(cmd)
@@ -457,7 +457,6 @@ def configure_git(templates_path):
 
     # Make a project directory.
     cmd = f"mkdir -p {project_path}"
-    breakpoint()
     run_server_cmd_ssh(cmd)
 
     cmd = f"chown -R {dsd_config.server_username}:{dsd_config.server_username} {project_path}"

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -424,7 +424,10 @@ def configure_git(templates_path):
             plugin_utils.write_output(stderr)
 
     # Copy key to server.
-    cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
+    if plugin_config.path_ssh_key:
+        cmd = f"ssh-copy-id -f -i {path_keyfile.as_posix()} -o IdentityFile={plugin_config.path_ssh_key} {dsd_config.server_username}@{plugin_config.ip_address}"
+    else:
+        cmd = f"ssh-copy-id -i ~/.ssh/id_rsa_git.pub git@{ipaddr}"
     output_obj = plugin_utils.run_quick_command(cmd)
     stdout, stderr = output_obj.stdout.decode(), output_obj.stderr.decode()
     plugin_utils.write_output(stdout)

--- a/dsd_vps/utils.py
+++ b/dsd_vps/utils.py
@@ -16,7 +16,7 @@ from .plugin_config import plugin_config
 
 
 def get_ssh_key_ids_digitalocean():
-    """Get any existing ssh key IDs on Digital Ocean."""
+    """Get a DigitalOcean ssh key ID."""
     cmd = "doctl compute ssh-key list -o json"
     output = plugin_utils.run_quick_command(cmd, skip_logging=True).stdout.decode()
     key_dicts = json.loads(output)
@@ -30,7 +30,8 @@ def get_ssh_key_ids_digitalocean():
         proceed = plugin_utils.get_confirmation(msg, skip_logging=True)
 
         if proceed:
-            return ssh_key_id
+            plugin_utils.ssh_key_id = ssh_key_id
+            return
         else:
             msg = "Can't proceed without an SSH key id."
             raise DSDCommandError(msg)

--- a/tests/integration_tests/reference_files/plugin_help_text.txt
+++ b/tests/integration_tests/reference_files/plugin_help_text.txt
@@ -1,4 +1,5 @@
 Options for dsd-vps:
   Plugin-specific CLI args for dsd-vps
 
+  --platform PLATFORM   Hosting platform, such as digital_ocean.
   --ssh-key SSH_KEY     Path to private SSH key for accessing VPS instance.

--- a/tests/integration_tests/reference_files/plugin_help_text.txt
+++ b/tests/integration_tests/reference_files/plugin_help_text.txt
@@ -1,0 +1,4 @@
+Options for dsd-vps:
+  Plugin-specific CLI args for dsd-vps
+
+  --ssh-key SSH_KEY     Path to private SSH key for accessing VPS instance.

--- a/tests/integration_tests/test_custom_cli_arg.py
+++ b/tests/integration_tests/test_custom_cli_arg.py
@@ -1,0 +1,22 @@
+"""Test a custom plugin-specific CLI arg.
+"""
+
+import pytest
+
+from tests.integration_tests.conftest import tmp_project
+from tests.integration_tests.utils import manage_sample_project as msp
+
+# Skip the default module-level `manage.py deploy call`, so we can call
+# `deploy` with our own set of plugin-specific CLI args.
+pytestmark = pytest.mark.skip_auto_dsd_call
+
+
+# def test_vm_size_arg(tmp_project, request):
+#     """Test that a custom vm size is written to fly.toml."""
+#     cmd = "python manage.py deploy --vm-size shared-cpu-2x"
+#     msp.call_deploy(tmp_project, cmd, platform="fly_io")
+
+#     path = tmp_project / "fly.toml"
+#     contents_fly_toml = path.read_text()
+
+#     assert 'size = "shared-cpu-2x"' in contents_fly_toml

--- a/tests/integration_tests/test_help_output.py
+++ b/tests/integration_tests/test_help_output.py
@@ -1,0 +1,35 @@
+"""Test the help output when dsd-vps is installed.
+
+The core django-simple-deploy library tests its own help output.
+This test checks that plugin-specific options are included in the help output.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration_tests.conftest import tmp_project
+from tests.integration_tests.utils import manage_sample_project as msp
+
+# Skip the default module-level `manage.py deploy call`, so we can call
+# `deploy` with our own set of plugin-specific CLI args.
+pytestmark = pytest.mark.skip_auto_dsd_call
+
+
+def test_plugin_help_output(tmp_project, request):
+    """Test that dsd-vps CLI args are included in help output.
+
+    Note: When updating this, run `manage.py deploy --help` in a terminal set
+    to 80 characters wide. That splits help text at the same places as the 
+    test environment.
+    On macOS, you can simply run:
+        $ COLUMNS=80 python manage.py deploy --help
+    """
+    cmd = "python manage.py deploy --help"
+    stdout, stderr = msp.call_deploy(tmp_project, cmd)
+
+    path_reference = Path(__file__).parent / "reference_files" / "plugin_help_text.txt"
+    help_lines = path_reference.read_text().splitlines()
+
+    for line in help_lines:
+        assert line in stdout

--- a/tests/integration_tests/test_vps_config.py
+++ b/tests/integration_tests/test_vps_config.py
@@ -16,6 +16,10 @@ from tests.integration_tests.conftest import (
 )
 
 
+# Skip until more stable configuration to test.
+pytestmark = pytest.mark.skip
+
+
 # --- Fixtures ---
 
 


### PR DESCRIPTION
Most people will want to use ssh keys to access the VPS instance, instead of a username and password. This PR supports key-based access to the instance.

This PR has code that's specific to Digital Ocean. The fully automated mode in the key-based workflow creates the droplet (DO's name for a VPS instance). 

This PR may also have broken the un/pw based workflow. This PR is required to support e2e tests. I'll write e2e tests next, and then review issues with both workflows.